### PR TITLE
레벨 2: N+1 문제

### DIFF
--- a/src/main/java/org/example/expert/domain/todo/repository/TodoRepository.java
+++ b/src/main/java/org/example/expert/domain/todo/repository/TodoRepository.java
@@ -3,6 +3,7 @@ package org.example.expert.domain.todo.repository;
 import org.example.expert.domain.todo.entity.Todo;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -11,12 +12,18 @@ import java.util.Optional;
 
 public interface TodoRepository extends JpaRepository<Todo, Long> {
 
+    // 기존 코드 > 테스트 코드를 위해 코드 삭제 X
     @Query("SELECT t FROM Todo t LEFT JOIN FETCH t.user u ORDER BY t.modifiedAt DESC")
     Page<Todo> findAllByOrderByModifiedAtDesc(Pageable pageable);
 
-    @Query("SELECT t FROM Todo t " +
-            "LEFT JOIN FETCH t.user " +
-            "WHERE t.id = :todoId")
+    // N+1 문제 -> 수정 코드
+    @EntityGraph(attributePaths = "user")
+    @Query("SELECT t FROM Todo t ORDER BY t.modifiedAt DESC") // N+1 문제 발생하도록
+    Page<Todo> findAllWithUserOrderByModifiedAtDesc(Pageable pageable);
+
+    // N+1 문제 -> 수정 코드
+    @EntityGraph(attributePaths = "user")
+    @Query("SELECT t FROM Todo t WHERE t.id = :todoId")
     Optional<Todo> findByIdWithUser(@Param("todoId") Long todoId);
 
     int countById(Long todoId);

--- a/src/main/java/org/example/expert/domain/todo/service/TodoService.java
+++ b/src/main/java/org/example/expert/domain/todo/service/TodoService.java
@@ -51,7 +51,11 @@ public class TodoService {
     public Page<TodoResponse> getTodos(int page, int size) {
         Pageable pageable = PageRequest.of(page - 1, size);
 
-        Page<Todo> todos = todoRepository.findAllByOrderByModifiedAtDesc(pageable);
+        //기존 코드 (N+1 문제)
+//        Page<Todo> todos = todoRepository.findAllByOrderByModifiedAtDesc(pageable);
+
+        //수정 코드 (N+1 문제 해결)
+        Page<Todo> todos = todoRepository.findAllWithUserOrderByModifiedAtDesc(pageable);
 
         return todos.map(todo -> new TodoResponse(
                 todo.getId(),


### PR DESCRIPTION
(Refactor)
- @EntityGraph 활용하여 N+1 문제 방지할 수 있는 코드로 수정

> TodoRepository -> findAllByOrderByModifiedAtDesc
- 기존 LEFT JOIN FETCH 코드를 @EntityGraph로 코드 수정
- 코드가 수정됨에 따라 메서드 명 수정
- findAllByOrderByModifiedAtDesc -> findAllWithUserOrderByModifiedAtDesc

> TodoService
- 레포지토리에서 코드가 수정됨에 따라 TodoService 에도 수정된 메서드로 작성