### PR TITLE
레벨 3-2: 테스트 코드 연습 2 > 잘못된 예외 처리 타입

### DIFF
--- a/src/test/java/org/example/expert/domain/comment/service/CommentServiceTest.java
+++ b/src/test/java/org/example/expert/domain/comment/service/CommentServiceTest.java
@@ -5,6 +5,7 @@ import org.example.expert.domain.comment.dto.response.CommentSaveResponse;
 import org.example.expert.domain.comment.entity.Comment;
 import org.example.expert.domain.comment.repository.CommentRepository;
 import org.example.expert.domain.common.dto.AuthUser;
+import org.example.expert.domain.common.exception.InvalidRequestException;
 import org.example.expert.domain.common.exception.ServerException;
 import org.example.expert.domain.todo.entity.Todo;
 import org.example.expert.domain.todo.repository.TodoRepository;
@@ -43,7 +44,7 @@ class CommentServiceTest {
         given(todoRepository.findById(anyLong())).willReturn(Optional.empty());
 
         // when
-        ServerException exception = assertThrows(ServerException.class, () -> {
+        InvalidRequestException exception = assertThrows(InvalidRequestException.class, () -> {
             commentService.saveComment(authUser, todoId, request);
         });
 


### PR DESCRIPTION
(Fix)
> comment_등록_중_할일을_찾지_못해_에러가_발생한다()
- todoRepository.findById 의 경우 todo 레포지토리에서 할일 todo 목록을 ID로 찾는 메서드
- 해당 메서드에서 발생하는 예외는 InvalidRequestException 이므로 잘못된 예외 처리 타입 수정
- ServerException -> InvalidRequestException